### PR TITLE
Column randomizer seed

### DIFF
--- a/presidio-analyzer/presidio_analyzer/entity_source.py
+++ b/presidio-analyzer/presidio_analyzer/entity_source.py
@@ -6,6 +6,7 @@ import re
 
 logger = PresidioLogger("presidio")
 
+
 @dataclass
 class EntitySource:
     """
@@ -35,9 +36,10 @@ class EntitySource:
         Apply the equivalent of str.replace across the source text.
         """
 
+
 class Column(EntitySource):
 
-    def __init__(self, series, sample_size=None, **kwargs):
+    def __init__(self, series, sample_size=None, randomizer_seed=None, **kwargs):
         if not sample_size:
             logger.warning(
                 "No sample size given, all rows will be analyzed "
@@ -45,7 +47,7 @@ class Column(EntitySource):
             col = series
         else:
             if sample_size <= len(series):
-                col = series.sample(sample_size)
+                col = series.sample(sample_size, random_state=randomizer_seed)
             else:
                 col = series
 


### PR DESCRIPTION
Allow access to pandas sampler randomizer seed.

**Note:**
I tested passing both `None`, and not passing anything, to the pandas sample `random_state`, and both seem to operate identically.